### PR TITLE
ensures environment name is consistent

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -20,16 +20,28 @@ class Constants
 		define('APP_URL', plugin_dir_url($dir) . 'app/');
 		define('APP_PATH', $dir.'/');
 
+        $envPath = APP_PATH.'.env.php';
+
 		/**
 		 * Load dotenv if .env file is present
 		 */
-		if (file_exists($dir.'/.env.php')) {
+		if (file_exists($envPath)) {
 			try {
-				DotEnv::load($dir.'/.env.php');
+				DotEnv::load($envPath);
 				DotEnv::copyVarsToEnv();
 			} catch (\Throwable $e ) {
 				error_log('ENV load fail: Unable to properly load .env.php file, check that it is formed correctly');
 			}
+
+            // Ensure WP_ENVIRONMENT_TYPE is not a WP default value
+            if (!defined('WP_ENVIRONMENT_TYPE')){
+                define('WP_ENVIRONMENT_TYPE',env('ENVIRONMENT'));
+            }
+
+            // Ensure ENV ENVIRONMENT and WP_ENVIRONMENT_TYPE agree.
+            if ( env('ENVIRONMENT') !== wp_get_environment_type() ){
+                throw new \Error("$envPath thinks this is '" . env("ENVIRONMENT") . "' and wp_get_environment_type() thinks this is '".wp_get_environment_type()."' and WP_ENVIRONMENT_TYPE is '".WP_ENVIRONMENT_TYPE."'. They must agree.");
+            }
 		}
 
 		/**

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -67,13 +67,20 @@ class Constants
 	private static function env_set($key, $default)
 	{
 		// Check if we have env value
-		$env_value = env($key, $default);
+		$env_value = env($key);
 
-		if (! isset($env_value)) {
-			return;
-		}
+        // If not value or default move along
+        if (!isset($env_value) && !isset($default)){
+            return;
+        }
 
-		// if not defined
+        // Use the default if env_value is not set
+        if(!isset($env_value)){
+            DotEnv::set($key,$default);
+            $env_value = $default;
+        }
+
+		// Make default env_vars global vars.
 		if (defined($key)) {
 			return;
 		}

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -33,15 +33,24 @@ class Constants
 				error_log('ENV load fail: Unable to properly load .env.php file, check that it is formed correctly');
 			}
 
-            // Ensure WP_ENVIRONMENT_TYPE is not a WP default value
-            if (!defined('WP_ENVIRONMENT_TYPE')){
-                define('WP_ENVIRONMENT_TYPE',env('ENVIRONMENT'));
-            }
+			// For backwards compatibility, we will not throw errors unless ENVIRONMENT is actually defined in .env.php
+			if (env("ENVIRONMENT")){
 
-            // Ensure ENV ENVIRONMENT and WP_ENVIRONMENT_TYPE agree.
-            if ( env('ENVIRONMENT') !== wp_get_environment_type() ){
-                throw new \Error("$envPath thinks this is '" . env("ENVIRONMENT") . "' and wp_get_environment_type() thinks this is '".wp_get_environment_type()."' and WP_ENVIRONMENT_TYPE is '".WP_ENVIRONMENT_TYPE."'. They must agree.");
-            }
+				// wp_get_environment_type() uses WP_ENVIRONMENT_TYPE, so update to match if not already defined
+				if (!defined('WP_ENVIRONMENT_TYPE')){
+					define('WP_ENVIRONMENT_TYPE',env('ENVIRONMENT'));
+				}
+
+				// Ensure env('ENVIRONMENT') and wp_get_environment_type() agree as these are the
+				// expected ways to access the environment name.
+				if ( env('ENVIRONMENT') !== wp_get_environment_type() ){
+					throw new \Error("Conflicting environment names. "
+						. "env('ENVIRONMENT') is '" . env("ENVIRONMENT") . "'. "
+						. "wp_get_environment_type() is '".wp_get_environment_type()."'. "
+						. "They must agree."
+					);
+				}
+			}
 		}
 
 		/**

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -7,11 +7,11 @@ use Arrilot\DotEnv\DotEnv;
 class Constants
 {
 	private static $env_vars = [
-		'ENVIRONMENT'           => 'production',
-		'ACF_LITE'              => true,
-		'DISABLE_WP_CRON'       => false,
-		'FILE_MOD_ALLOWED'      => false,
-		'SENTRY_URL'            => null,
+		'ENVIRONMENT'		   => 'production',
+		'ACF_LITE'			  => true,
+		'DISABLE_WP_CRON'	   => false,
+		'FILE_MOD_ALLOWED'	  => false,
+		'SENTRY_URL'			=> null,
 	];
 
 	public static function init($dir)
@@ -20,7 +20,7 @@ class Constants
 		define('APP_URL', plugin_dir_url($dir) . 'app/');
 		define('APP_PATH', $dir.'/');
 
-        $envPath = APP_PATH.'.env.php';
+		$envPath = APP_PATH.'.env.php';
 
 		/**
 		 * Load dotenv if .env file is present

--- a/src/bootstrap/bootstrap.php
+++ b/src/bootstrap/bootstrap.php
@@ -26,6 +26,7 @@ function bootstrap( $dir ) {
 	 * Autoload all php files in /src/
 	 */
 	autoload( $dir . '/src' );
+    autoload( $dir . '/src-psr-4' );
 
 	/**
 	 * Kick off third party integrations as dictated by our .env variables

--- a/src/bootstrap/bootstrap.php
+++ b/src/bootstrap/bootstrap.php
@@ -26,7 +26,6 @@ function bootstrap( $dir ) {
 	 * Autoload all php files in /src/
 	 */
 	autoload( $dir . '/src' );
-	autoload( $dir . '/src-psr-4' );
 
 	/**
 	 * Kick off third party integrations as dictated by our .env variables

--- a/src/bootstrap/bootstrap.php
+++ b/src/bootstrap/bootstrap.php
@@ -26,7 +26,7 @@ function bootstrap( $dir ) {
 	 * Autoload all php files in /src/
 	 */
 	autoload( $dir . '/src' );
-    autoload( $dir . '/src-psr-4' );
+	autoload( $dir . '/src-psr-4' );
 
 	/**
 	 * Kick off third party integrations as dictated by our .env variables


### PR DESCRIPTION
When a .env.php file is used and ENVIRONMENT is defined, ensure that it matches the standard Wordpress function wp_get_environment_type()